### PR TITLE
feat: EC2 고정 IP 할당 (#4)

### DIFF
--- a/live/dev/db-ha/main.tf
+++ b/live/dev/db-ha/main.tf
@@ -20,12 +20,14 @@ module "db_ha" {
   name = "cloud-ha-lab-dev"
 
   # 네트워크 모듈에서 만든 값 가져오기
-  vpc_id             = data.terraform_remote_state.network.outputs.vpc_id
+  vpc_id               = data.terraform_remote_state.network.outputs.vpc_id
   private_subnet_ids = data.terraform_remote_state.network.outputs.private_subnet_ids
 
   # 🔥 여기 중요: tfvars에서 넣어준 값 사용
-  ami_id       = var.ami_id
-  ssh_key_name = var.ssh_key_name
+  ami_id         = var.ami_id
+  ssh_key_name  = var.ssh_key_name
+  # 🔽 'private_ips' 변수를 모듈에 전달하도록 추가
+  private_ips    = var.private_ips
 
   # 온프레 & WireGuard 대역에서 DB 접근 허용
   allowed_onprem_cidrs = [

--- a/live/dev/db-ha/variables.tf
+++ b/live/dev/db-ha/variables.tf
@@ -1,7 +1,14 @@
-variable "ssh_key_name" {
-  type = string
+variable "ami_id" {
+  description = "DB EC2 인스턴스에 사용할 AMI ID"
+  type        = string
 }
 
-variable "ami_id" {
-  type = string
+variable "ssh_key_name" {
+  description = "EC2 인스턴스에 사용할 SSH 키 이름"
+  type        = string
+}
+
+variable "private_ips" {
+  description = "DB 인스턴스 2대에 고정 할당할 프라이빗 IP 리스트"
+  type        = list(string)
 }

--- a/modules/db/variables.tf
+++ b/modules/db/variables.tf
@@ -1,13 +1,21 @@
 variable "name" {
-  type = string
+  description = "DB 인스턴스의 기본 이름 (예: cloud-ha-lab-dev)"
+  type        = string
 }
 
 variable "vpc_id" {
   type = string
 }
 
+# 🔽 'list(string)'로 다시 변경 (님의 원본 코드)
 variable "private_subnet_ids" {
-  description = "Private subnets from network module"
+  description = "DB 인스턴스 2대가 생성될 Private Subnet ID 리스트"
+  type        = list(string)
+}
+
+# 🔽 'private_ips' 리스트 변수를 새로 추가
+variable "private_ips" {
+  description = "EC2 인스턴스에 고정 할당할 프라이빗 IP 주소 리스트"
   type        = list(string)
 }
 
@@ -26,7 +34,7 @@ variable "ssh_key_name" {
 }
 
 variable "allowed_onprem_cidrs" {
-  description = "CIDRs allowed for SSH/ICMP (e.g. [\"172.16.60.0/24\", \"172.16.4.0/24\"])"
+  description = "SSH/ICMP를 허용할 온프레미스 CIDR 대역"
   type        = list(string)
 }
 


### PR DESCRIPTION
close #4

## 📌 Summary
feat: EC2 인스턴스에 프라이빗 고정 IP 할당

## ✍️ Description
`terraform apply/destroy`를 반복 실행할 때마다 DB EC2 인스턴스의 프라이빗 IP가 변경되어, Patroni/etcd 클러스터 설정에 문제가 생기는 것을 해결합니다.

`modules/db` 모듈이 `private_ips` (IP 주소 리스트)를 변수로 받도록 수정했습니다.
`live/dev/db-ha`에서 이 모듈을 호출할 때 `terraform.tfvars`에 정의된 고정 IP 리스트(`["10.0.137.255", "10.0.159.178"]`)를 전달하도록 변경했습니다.

- close: #4

## 💡 PR Point
`modules/db/main.tf`의 `aws_instance` 리소스가 `count.index`를 사용해 IP와 서브넷을 매칭합니다.

따라서 `live/dev/db-ha/main.tf`에서 모듈을 호출할 때, `private_ips` 변수의 리스트 순서와 `private_subnet_ids` 변수의 리스트 순서가 반드시 일치해야 합니다.

- `private_ips[0]` (`10.0.137.255`)는 `private_subnet_ids[0]` (db-1의 서브넷)에 할당
- `private_ips[1]` (`10.0.159.178`)는 `private_subnet_ids[1]` (db-2의 서브넷)에 할당

## 📚 Reference 
## 🔥 Test
1.  `live/dev/db-ha` 디렉터리로 이동
2.  `terraform plan` 실행
3.  실행 계획(plan)에서 생성될 리소스 2개의 `private_ip` 속성 확인
    - `module.db_ha.aws_instance.db[0]`의 `private_ip`가 `10.0.137.255`인지 확인
    - `module.db_ha.aws_instance.db[1]`의 `private_ip`가 `10.0.159.178`인지 확인