### PR TITLE
fix: 클러스터 내부 통신 (Ping, etcd) 허용 (#4)

### DIFF
--- a/modules/db/main.tf
+++ b/modules/db/main.tf
@@ -8,7 +8,7 @@ resource "aws_security_group" "db" {
     from_port   = 2379
     to_port     = 2379
     protocol    = "tcp"
-    cidr_blocks = ["10.0.0.0/16"]
+    cidr_blocks = ["10.0.0.0/16"] # (참고: 앱 서버 등 VPC 내부의 다른 리소스용)
     description = "etcd Client Port (Patroni)"
   }
 
@@ -69,22 +69,39 @@ resource "aws_security_group" "db" {
   }
 }
 
-# EC2 2대: 각 AZ의 private subnet 하나씩
-# private_subnet_ids[0], private_subnet_ids[1] 기준
+# 🔽 [수정 완료] 핑(Ping) 및 내부 통신을 위한 규칙을 별도 리소스로 분리
+resource "aws_security_group_rule" "db_self_ingress" {
+  type                      = "ingress"
+  from_port                 = 0
+  to_port                   = 0
+  protocol                  = "-1" # 모든 프로토콜
+  security_group_id         = aws_security_group.db.id # 이 규칙을 적용할 대상 SG
+  source_security_group_id  = aws_security_group.db.id # "자기 자신"의 ID를 소스로 지정
+  description               = "Allow all internal cluster traffic (Patroni, etcd, Ping)"
+}
 
+
+# EC2 리소스 (변경 없음)
 resource "aws_instance" "db" {
-  count = 2
+  # 리스트의 길이만큼 (2개) 생성
+  count = length(var.private_subnet_ids)
 
-  ami                    = var.ami_id
-  instance_type          = var.instance_type
-  subnet_id              = var.private_subnet_ids[count.index]
+  ami                   = var.ami_id
+  instance_type         = var.instance_type
+  key_name              = var.ssh_key_name
   vpc_security_group_ids = [aws_security_group.db.id]
-  key_name               = var.ssh_key_name
   associate_public_ip_address = false
+
+  # Subnet ID를 리스트에서 하나씩 가져와 적용
+  subnet_id             = var.private_subnet_ids[count.index]
+
+  # Private IP를 리스트에서 하나씩 가져와 적용
+  private_ip            = var.private_ips[count.index]
 
   user_data = var.user_data
 
   tags = {
+    # 태그가 'db-1', 'db-2'로 생성되도록 count.index 사용
     Name = "${var.name}-db-${count.index + 1}"
     Role = "db-ha-node"
   }


### PR DESCRIPTION
## 📌 Summary
fix: DB 클러스터 노드 간 내부 통신 (Ping, etcd 등) 허용

## ✍️ Description
- **문제점:** EC2 고정 IP 기능(PR #4)을 머지한 후, `db-1`과 `db-2`가 동일한 보안 그룹(`db-sg`)에 속해 있음에도 불구하고 서로 `ping` 통신이 차단되었습니다.
- **원인:** `db-sg`에 온프레미스 대역 외의 ICMP 규칙이 없었고, etcd/Patroni 규칙도 `10.0.0.0/16` CIDR 기반이라 클러스터 내부 통신에 잠재적 문제가 있었습니다.
- **해결:** `aws_security_group_rule` 리소스를 별도로 생성하여, `db-sg` 보안 그룹 멤버끼리는 모든 프로토콜(`-1`)의 통신을 허용하도록 '자체 참조(self-referencing)' 규칙을 추가했습니다.

- close: (이 PR이 닫을 새 이슈가 있다면 여기에 번호를 적으세요. 예: `close #6`)

## 💡 PR Point
- `aws_security_group` 리소스 내부의 `ingress` 블록에서는 `security_groups = [aws_security_group.db.id]`처럼 자기 자신을 참조할 수 없습니다. (테라폼 `Self-referential block` 에러 발생)
- 이 문제를 해결하기 위해, `aws_security_group` 리소스(껍데기)와 `aws_security_group_rule` 리소스(자체 참조 규칙)를 분리하여 정의했습니다.
- 이 규칙 하나로 `db-1`과 `db-2` 간의 Ping, etcd, Patroni, PostgreSQL 복제 트래픽을 모두 허용할 수 있습니다.

## 🔥 Test
1.  `live/dev/db-ha` 디렉터리에서 `terraform apply` 실행
2.  `aws_security_group_rule.db_self_ingress` 리소스가 성공적으로 생성되는지 확인
3.  `db-1` EC2 인스턴스에 SSH로 접속
4.  `ping 10.0.159.178` (db-2의 IP) 실행
5.  `100% packet loss` 없이 `ping`이 성공하는지 확인